### PR TITLE
Club combobox and replace tournament select with custom dropdown

### DIFF
--- a/app/webapp/main.py
+++ b/app/webapp/main.py
@@ -12,6 +12,7 @@ from martialmatch_scraper import (ALLOWED_CLUBS, EventNotFoundError,
                                   ParticipantsNotFoundError,
                                   ScheduleNotFoundError,
                                   fetch_all_tournament_ids,
+                                  fetch_event_clubs,
                                   get_participants_schedule)
 from pydantic import BaseModel, Field
 from pydantic import ValidationError as PydanticValidationError
@@ -55,13 +56,31 @@ async def get_tournaments():
 
 @app.get("/api/clubs")
 async def get_clubs():
-    """Return all allowed clubs."""
+    """Return featured clubs."""
     return {
         "clubs": [
-            {"id": k, "display_name": v["display_name"]}
+            {
+                "id": k,
+                "display_name": v["display_name"],
+                "academy": v["academy"],
+                "branch": v["branch"],
+            }
             for k, v in ALLOWED_CLUBS.items()
         ]
     }
+
+
+@app.get("/api/event-clubs")
+async def get_event_clubs(
+    event_id: str = Query(..., min_length=1, max_length=100, description="Tournament event ID"),
+):
+    try:
+        clubs = fetch_event_clubs(event_id.strip())
+        return {"clubs": clubs}
+    except EventNotFoundError as e:
+        return {"clubs": [], "message": str(e)}
+    except Exception:
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @app.get("/api/server-time")
@@ -73,11 +92,14 @@ async def get_server_time():
 @app.get("/api/participants")
 async def get_participants(
     event_id: str = Query(..., description="Tournament event ID"),
-    club_id: str = Query(..., description="Club ID from allowed clubs"),
+    academy: str = Query(..., description="Club academy name"),
+    branch: str = Query("", description="Club branch name"),
 ) -> Dict[str, Any]:
     try:
-        params = ParticipantRequest(event_id=event_id, club_id=club_id)
-        schedule_per_day = get_participants_schedule(params.event_id, params.club_id)
+        params = ParticipantRequest(event_id=event_id, academy=academy, branch=branch)
+        schedule_per_day = get_participants_schedule(
+            params.event_id, params.academy, params.branch
+        )
         return {"schedule": schedule_per_day}
     except PydanticValidationError as e:
         error_msg = e.errors()[0]["msg"] if e.errors() else "Validation error"
@@ -92,23 +114,12 @@ async def get_participants(
 
 # Models for validation
 class ParticipantRequest(BaseModel):
-    event_id: str = Field(
-        ..., min_length=1, max_length=100, description="Tournament event ID"
-    )
-    club_id: str = Field(
-        ..., min_length=1, max_length=100, description="Club ID from allowed clubs"
-    )
+    event_id: str = Field(..., min_length=1, max_length=100, description="Tournament event ID")
+    academy: str = Field(..., min_length=1, max_length=200, description="Club academy name")
+    branch: str = Field("", max_length=200, description="Club branch name")
 
-    @field_validator("event_id", "club_id")
+    @field_validator("event_id", "academy", "branch")
     @classmethod
     def strip_value(cls, v: str) -> str:
         """Strip whitespace from input values."""
         return v.strip()
-
-    @field_validator("club_id")
-    @classmethod
-    def validate_club_exists(cls, v: str) -> str:
-        """Validate that the club exists in ALLOWED_CLUBS."""
-        if v not in ALLOWED_CLUBS:
-            raise ValueError(f"Club ID {v} is not in the allowed clubs list")
-        return v

--- a/app/webapp/martialmatch_scraper.py
+++ b/app/webapp/martialmatch_scraper.py
@@ -92,24 +92,25 @@ def cache_with_ttl(cache):
 
 
 @cache_with_ttl(participants_cache)
-def fetch_bjj_participants(event_id, club_id):
-    if club_id not in ALLOWED_CLUBS:
-        raise ValueError(f"Club {club_id} is not in the allowed clubs list")
+def _fetch_participants_json(event_id):
+    """Fetch and cache the raw starting-lists JSON for an event."""
     numeric_id = extract_numeric_id(event_id)
     url = f"{BASE_URL}/api/events/{numeric_id}/starting-lists/public"
     try:
-        json_data = make_api_request(url, API_COOKIES).json()
+        return make_api_request(url, API_COOKIES).json()
     except EventNotFoundHTTPError:
         raise EventNotFoundError()
+
+
+def fetch_bjj_participants(event_id, academy, branch=""):
+    json_data = _fetch_participants_json(event_id)
     start_time_prof = time.time()
-    club = ALLOWED_CLUBS[club_id]
     participant_data = []
     for cat in json_data.get("categories", []):
         category_name = cat.get("category", "")
         for comp in cat.get("competitors", []):
-            if (
-                comp.get("academy") == club["academy"]
-                and comp.get("branch", "").strip() == club["branch"]
+            if comp.get("academy") == academy and (
+                not branch or comp.get("branch", "").strip() == branch
             ):
                 name = f"{comp['firstName']} {comp['lastName']}"
                 participant_data.append((name, category_name))
@@ -171,6 +172,27 @@ def fetch_bjj_schedule(event_id):
     return df
 
 
+def fetch_event_clubs(event_id):
+    json_data = _fetch_participants_json(event_id)
+    seen = set()
+    clubs = []
+    for cat in json_data.get("categories", []):
+        for comp in cat.get("competitors", []):
+            academy = comp.get("academy", "").strip()
+            branch = comp.get("branch", "").strip()
+            if not academy:
+                continue
+            key = (academy, branch)
+            if key not in seen:
+                seen.add(key)
+                display = f"{academy} ({branch})" if branch else academy
+                clubs.append(
+                    {"academy": academy, "branch": branch, "display_name": display}
+                )
+    clubs.sort(key=lambda c: c["display_name"].lower())
+    return clubs
+
+
 def fetch_all_tournament_ids():
     """Fetch tournament IDs from both active and archive pages."""
     return {
@@ -200,8 +222,8 @@ def fetch_tournament_ids(url):
     return tournament_ids
 
 
-def get_participants_schedule(event_id, club_id):
-    participants = fetch_bjj_participants(event_id, club_id)
+def get_participants_schedule(event_id, academy, branch=""):
+    participants = fetch_bjj_participants(event_id, academy, branch)
     if participants.empty:
         raise ParticipantsNotFoundError()
     schedule = fetch_bjj_schedule(event_id)

--- a/app/webapp/static/css/style.css
+++ b/app/webapp/static/css/style.css
@@ -104,14 +104,95 @@ h1 {
     color: var(--color-text);
 }
 
-select {
+/* Trigger (tournament click-only dropdown) */
+.combobox-trigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space);
+    width: 100%;
+    min-width: 0;
+    padding: var(--space);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    font-size: var(--font-base);
+    font-family: inherit;
+    font-weight: normal;
+    background-color: var(--color-white);
+    color: var(--color-text);
+    text-align: left;
+    cursor: pointer;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+
+    &:hover {
+        border-color: var(--color-primary-light);
+        background-color: var(--color-white);
+        transform: none;
+        box-shadow: none;
+    }
+
+    &:active {
+        transform: none;
+        box-shadow: none;
+    }
+
+    &:focus {
+        outline: none;
+        border-color: var(--color-primary);
+        box-shadow: 0 0 0 3px rgba(20, 112, 182, 0.1);
+    }
+
+    &:disabled {
+        background-color: var(--color-background);
+        cursor: not-allowed;
+        color: var(--color-text-light);
+    }
+
+    &.combobox-open {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        border-bottom-color: transparent;
+    }
+}
+
+.combobox-trigger-text {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.combobox-arrow {
+    flex-shrink: 0;
+    font-size: 0.75em;
+    color: var(--color-text-light);
+    transition: transform 0.2s ease;
+}
+
+.combobox-trigger.combobox-open .combobox-arrow {
+    transform: rotate(180deg);
+}
+
+.combobox-empty {
+    color: var(--color-text-light);
+    pointer-events: none;
+    font-style: italic;
+}
+
+/* Combobox Styles */
+.combobox-wrapper {
+    position: relative;
+    width: 100%;
+}
+
+.combobox-wrapper input[type="text"] {
     width: 100%;
     padding: var(--space);
     border: 1px solid var(--color-border);
     border-radius: var(--radius);
     font-size: var(--font-base);
     background-color: var(--color-white);
-    transition: all 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
 
     &:hover {
         border-color: var(--color-primary-light);
@@ -127,6 +208,68 @@ select {
         background-color: var(--color-background);
         cursor: not-allowed;
     }
+
+    &.combobox-open {
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        border-bottom-color: transparent;
+    }
+}
+
+.combobox-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+    background-color: var(--color-white);
+    border: 1px solid var(--color-primary);
+    border-top: none;
+    border-radius: 0 0 var(--radius) var(--radius);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
+    max-height: 240px;
+    overflow-y: auto;
+}
+
+.combobox-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: calc(0.6 * var(--space)) var(--space);
+    cursor: pointer;
+    font-size: var(--font-base);
+    color: var(--color-text);
+    transition: background-color 0.15s ease;
+
+    &:hover,
+    &.active {
+        background-color: var(--color-background);
+    }
+}
+
+.featured-badge {
+    color: var(--color-primary-light);
+    font-size: 0.8em;
+    flex-shrink: 0;
+}
+
+.combobox-separator {
+    height: 1px;
+    background-color: var(--color-border);
+    margin: 4px 0;
+    padding: 0;
+    pointer-events: none;
+}
+
+.combobox-loading {
+    padding: calc(0.5 * var(--space)) var(--space);
+    font-size: var(--font-small);
+    color: var(--color-text-light);
+    font-style: italic;
+    pointer-events: none;
 }
 
 /* Button Styles */

--- a/app/webapp/static/js/main.js
+++ b/app/webapp/static/js/main.js
@@ -7,13 +7,25 @@ document.addEventListener("DOMContentLoaded", function () {
     results: document.getElementById("results"),
     error: document.getElementById("error"),
     scheduleContainer: document.getElementById("scheduleContainer"),
-    tournamentSelect: document.getElementById("tournamentSelect"),
-    clubSelect: document.getElementById("clubSelect"),
+    tournamentTrigger: document.getElementById("tournamentTrigger"),
+    tournamentDisplay: document.getElementById("tournamentDisplay"),
+    tournamentDropdown: document.getElementById("tournamentDropdown"),
+    clubInput: document.getElementById("clubInput"),
+    clubDropdown: document.getElementById("clubDropdown"),
+    clubAcademy: document.getElementById("clubAcademy"),
+    clubBranch: document.getElementById("clubBranch"),
     tournamentTypeRadios: document.getElementsByName("tournamentType"),
   };
 
   let tournamentData = { active: [], archived: [] };
+  let currentTournaments = [];
+  let selectedTournamentId = null;
   let serverTimestamp = null;
+  let featuredClubs = [];
+  let eventClubs = [];
+  let eventClubsLoading = false;
+  let currentFiltered = [];
+  let activeIndex = -1;
 
   function escapeHtml(unsafe) {
     if (unsafe === null || unsafe === undefined) return "-";
@@ -40,7 +52,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   function buildDayHtml(day, items) {
     return `
-      <h3 class="collapsible-header collapsed">${day} <span class="collapse-indicator">&#8645;</span></h3>
+      <h3 class="collapsible-header collapsed">${escapeHtml(day)} <span class="collapse-indicator">&#8645;</span></h3>
       <div class="collapsible-content" style="display: none;">
         <table>
           <thead>
@@ -56,17 +68,109 @@ document.addEventListener("DOMContentLoaded", function () {
       </div>`;
   }
 
+  // --- Tournament dropdown ---
+
+  function openTournamentDropdown() {
+    elements.tournamentDropdown.hidden = false;
+    elements.tournamentTrigger.classList.add("combobox-open");
+    highlightSelectedTournament();
+  }
+
+  function closeTournamentDropdown() {
+    elements.tournamentDropdown.hidden = true;
+    elements.tournamentTrigger.classList.remove("combobox-open");
+  }
+
+  function highlightSelectedTournament() {
+    elements.tournamentDropdown.querySelectorAll(".combobox-item").forEach((el) => {
+      const t = currentTournaments[parseInt(el.dataset.idx, 10)];
+      el.classList.toggle("active", t && t.id === selectedTournamentId);
+    });
+    const active = elements.tournamentDropdown.querySelector(".combobox-item.active");
+    if (active) active.scrollIntoView({ block: "nearest" });
+  }
+
+  function setSelectedTournament(idx) {
+    const t = currentTournaments[idx];
+    if (!t) return;
+    selectedTournamentId = t.id;
+    elements.tournamentDisplay.textContent = t.name;
+    highlightSelectedTournament();
+    loadEventClubs(t.id);
+  }
+
+  function updateTournamentList(showArchived) {
+    currentTournaments = showArchived
+      ? tournamentData.archived
+      : tournamentData.active.slice(0, MAX_ACTIVE_TOURNAMENTS);
+
+    if (!currentTournaments.length) {
+      elements.tournamentDropdown.innerHTML =
+        '<li class="combobox-item combobox-empty">Brak turniejów</li>';
+      selectedTournamentId = null;
+      elements.tournamentDisplay.textContent = "Brak turniejów";
+      return;
+    }
+
+    elements.tournamentDropdown.innerHTML = currentTournaments
+      .map(
+        (t, i) =>
+          `<li class="combobox-item" data-idx="${i}" role="option" tabindex="-1">${escapeHtml(t.name)}</li>`
+      )
+      .join("");
+
+    setSelectedTournament(0);
+  }
+
+  elements.tournamentTrigger.addEventListener("click", () => {
+    if (elements.tournamentDropdown.hidden) openTournamentDropdown();
+    else closeTournamentDropdown();
+  });
+
+  elements.tournamentTrigger.addEventListener("blur", () => {
+    setTimeout(closeTournamentDropdown, 150);
+  });
+
+  elements.tournamentTrigger.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      if (elements.tournamentDropdown.hidden) openTournamentDropdown();
+      else closeTournamentDropdown();
+    } else if (e.key === "Escape") {
+      closeTournamentDropdown();
+    } else if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      if (elements.tournamentDropdown.hidden) {
+        openTournamentDropdown();
+        return;
+      }
+      const items = [
+        ...elements.tournamentDropdown.querySelectorAll(".combobox-item:not(.combobox-empty)"),
+      ];
+      const currentIdx = items.findIndex(
+        (el) => currentTournaments[parseInt(el.dataset.idx, 10)]?.id === selectedTournamentId
+      );
+      const next = Math.max(0, Math.min(items.length - 1, currentIdx + (e.key === "ArrowDown" ? 1 : -1)));
+      setSelectedTournament(parseInt(items[next].dataset.idx, 10));
+    }
+  });
+
+  elements.tournamentDropdown.addEventListener("mousedown", (e) => {
+    const item = e.target.closest(".combobox-item:not(.combobox-empty)");
+    if (!item) return;
+    e.preventDefault();
+    setSelectedTournament(parseInt(item.dataset.idx, 10));
+    closeTournamentDropdown();
+  });
+
   async function initializeTournaments() {
-    elements.tournamentSelect.disabled = true;
-    elements.tournamentSelect.innerHTML = '<option value="">Pobieram...</option>';
+    elements.tournamentTrigger.disabled = true;
+    elements.tournamentDisplay.textContent = "Pobieram...";
 
     try {
       const response = await fetch("/api/tournaments");
       const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.detail || "Failed to fetch tournaments");
-      }
+      if (!response.ok) throw new Error(data.detail || "Failed to fetch tournaments");
 
       tournamentData = data.tournaments;
       updateTournamentList(false);
@@ -77,67 +181,227 @@ document.addEventListener("DOMContentLoaded", function () {
         });
       });
     } catch (err) {
-      elements.tournamentSelect.innerHTML =
-        '<option value="">Błąd podczas ładowania</option>';
+      elements.tournamentDisplay.textContent = "Błąd podczas ładowania";
       console.error("Error fetching tournaments:", err);
     } finally {
-      elements.tournamentSelect.disabled = false;
+      elements.tournamentTrigger.disabled = false;
     }
   }
 
-  function updateTournamentList(showArchived) {
-    const tournaments = showArchived
-      ? tournamentData.archived
-      : tournamentData.active.slice(0, MAX_ACTIVE_TOURNAMENTS);
-    elements.tournamentSelect.innerHTML = tournaments.length
-      ? tournaments
-          .map((t) => `<option value="${t.id}">${t.name}</option>`)
-          .join("")
-      : '<option value="">Brak turniejów</option>';
+  // --- Club combobox ---
+
+  function isFeatured(club) {
+    return featuredClubs.some(
+      (f) => f.academy === club.academy && f.branch === club.branch
+    );
   }
 
+  function buildDropdownItems(query) {
+    const lower = query.toLowerCase();
+    const matches = (c) => !query || c.display_name.toLowerCase().includes(lower);
+
+    const filtered = featuredClubs.filter(matches);
+    const nonFeatured = eventClubs.filter((c) => !isFeatured(c) && matches(c));
+
+    currentFiltered = [...filtered, ...nonFeatured];
+    return { featured: filtered, nonFeatured };
+  }
+
+  function renderDropdown(query) {
+    activeIndex = -1;
+    const { featured, nonFeatured } = buildDropdownItems(query);
+
+    if (!currentFiltered.length && !eventClubsLoading) {
+      elements.clubDropdown.hidden = true;
+      elements.clubInput.classList.remove("combobox-open");
+      return;
+    }
+
+    let html = featured
+      .map(
+        (c, i) =>
+          `<li class="combobox-item" data-idx="${i}" role="option" tabindex="-1">` +
+          `<span class="featured-badge" aria-hidden="true">★</span>${escapeHtml(c.display_name)}` +
+          `</li>`
+      )
+      .join("");
+
+    if (featured.length && nonFeatured.length) {
+      html += `<li class="combobox-separator" role="separator"></li>`;
+    }
+
+    html += nonFeatured
+      .map(
+        (c, i) =>
+          `<li class="combobox-item" data-idx="${featured.length + i}" role="option" tabindex="-1">` +
+          escapeHtml(c.display_name) +
+          `</li>`
+      )
+      .join("");
+
+    if (eventClubsLoading) {
+      html += `<li class="combobox-loading">Pobieram kluby...</li>`;
+    }
+
+    elements.clubDropdown.innerHTML = html;
+    elements.clubDropdown.hidden = false;
+    elements.clubInput.classList.add("combobox-open");
+    updateActiveItem();
+  }
+
+  function updateActiveItem() {
+    elements.clubDropdown.querySelectorAll(".combobox-item").forEach((el, i) => {
+      el.classList.toggle("active", i === activeIndex);
+    });
+    if (activeIndex >= 0) {
+      const active = elements.clubDropdown.querySelector(
+        `.combobox-item[data-idx="${activeIndex}"]`
+      );
+      if (active) active.scrollIntoView({ block: "nearest" });
+    }
+  }
+
+  function selectClub(club) {
+    elements.clubInput.value = club.display_name;
+    elements.clubAcademy.value = club.academy;
+    elements.clubBranch.value = club.branch;
+    elements.clubDropdown.hidden = true;
+    elements.clubInput.classList.remove("combobox-open");
+    activeIndex = -1;
+  }
+
+  function clearSelection() {
+    elements.clubAcademy.value = "";
+    elements.clubBranch.value = "";
+  }
+
+  function closeDropdown() {
+    elements.clubDropdown.hidden = true;
+    elements.clubInput.classList.remove("combobox-open");
+    activeIndex = -1;
+  }
+
+  elements.clubInput.addEventListener("focus", () => {
+    elements.clubInput.select();
+    renderDropdown("");
+  });
+
+  elements.clubInput.addEventListener("click", () => {
+    if (elements.clubDropdown.hidden) renderDropdown("");
+  });
+
+  elements.clubInput.addEventListener("input", () => {
+    clearSelection();
+    renderDropdown(elements.clubInput.value);
+  });
+
+  elements.clubInput.addEventListener("blur", () => {
+    setTimeout(closeDropdown, 150);
+  });
+
+  elements.clubInput.addEventListener("keydown", (e) => {
+    const items = elements.clubDropdown.querySelectorAll(".combobox-item");
+    if (elements.clubDropdown.hidden || !items.length) return;
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      activeIndex = Math.min(activeIndex + 1, items.length - 1);
+      updateActiveItem();
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      activeIndex = Math.max(activeIndex - 1, -1);
+      updateActiveItem();
+    } else if (e.key === "Enter" && activeIndex >= 0) {
+      e.preventDefault();
+      selectClub(currentFiltered[activeIndex]);
+    } else if (e.key === "Escape") {
+      closeDropdown();
+    }
+  });
+
+  elements.clubDropdown.addEventListener("mousedown", (e) => {
+    const item = e.target.closest(".combobox-item");
+    if (!item) return;
+    e.preventDefault();
+    selectClub(currentFiltered[parseInt(item.dataset.idx, 10)]);
+  });
+
   async function initializeClubs() {
-    elements.clubSelect.disabled = true;
-    elements.clubSelect.innerHTML = '<option value="">Pobieram...</option>';
+    elements.clubInput.disabled = true;
+    elements.clubInput.placeholder = "Pobieram...";
 
     try {
       const response = await fetch("/api/clubs");
       const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.detail || "Failed to fetch clubs");
-      }
-
-      elements.clubSelect.innerHTML = data.clubs
-        .map((club) => `<option value="${club.id}">${club.display_name}</option>`)
-        .join("");
+      if (!response.ok) throw new Error(data.detail || "Failed to fetch clubs");
+      featuredClubs = data.clubs;
+      elements.clubInput.placeholder = "Wpisz lub wybierz klub...";
     } catch (err) {
-      elements.clubSelect.innerHTML =
-        '<option value="">Błąd podczas ładowania</option>';
+      elements.clubInput.placeholder = "Błąd podczas ładowania";
       console.error("Error fetching clubs:", err);
     } finally {
-      elements.clubSelect.disabled = false;
+      elements.clubInput.disabled = false;
     }
   }
 
+  async function loadEventClubs(eventId) {
+    if (!eventId) {
+      eventClubs = [];
+      return;
+    }
+    eventClubsLoading = true;
+    if (!elements.clubDropdown.hidden) renderDropdown(elements.clubInput.value);
+
+    try {
+      const response = await fetch(
+        `/api/event-clubs?event_id=${encodeURIComponent(eventId)}`
+      );
+      const data = await response.json();
+      if (eventId === selectedTournamentId) {
+        eventClubs = response.ok ? data.clubs || [] : [];
+      }
+    } catch (err) {
+      if (eventId === selectedTournamentId) eventClubs = [];
+      console.error("Error fetching event clubs:", err);
+    } finally {
+      eventClubsLoading = false;
+      if (!elements.clubDropdown.hidden) renderDropdown(elements.clubInput.value);
+    }
+  }
+
+  // --- Form submit ---
+
   async function handleFormSubmit(e) {
     e.preventDefault();
+
+    const eventId = selectedTournamentId;
+    const academy = elements.clubAcademy.value || elements.clubInput.value.trim();
+    const branch = elements.clubBranch.value;
+
+    if (!eventId) {
+      elements.error.textContent = "Wybierz zawody";
+      elements.error.style.display = "block";
+      return;
+    }
+
+    if (!academy) {
+      elements.error.textContent = "Wpisz lub wybierz klub";
+      elements.error.style.display = "block";
+      return;
+    }
 
     elements.loading.style.display = "block";
     elements.results.style.display = "none";
     elements.error.style.display = "none";
 
     try {
-      const eventId = elements.tournamentSelect.value;
-      const clubId = elements.clubSelect.value;
-
-      const response = await fetch(
-        `/api/participants?event_id=${eventId}&club_id=${clubId}`,
-      );
+      const url =
+        `/api/participants?event_id=${encodeURIComponent(eventId)}` +
+        `&academy=${encodeURIComponent(academy)}` +
+        `&branch=${encodeURIComponent(branch)}`;
+      const response = await fetch(url);
       const data = await response.json();
-      if (!response.ok) {
-        throw new Error(data.detail || "An error occurred");
-      }
+      if (!response.ok) throw new Error(data.detail || "An error occurred");
 
       if (Object.keys(data.schedule).length === 0) {
         const message = data.message || "Nie znaleziono danych.";
@@ -175,9 +439,7 @@ document.addEventListener("DOMContentLoaded", function () {
     try {
       const response = await fetch("/api/server-time");
       const data = await response.json();
-      if (response.ok) {
-        serverTimestamp = data.timestamp;
-      }
+      if (response.ok) serverTimestamp = data.timestamp;
     } catch (err) {
       console.error("Error fetching server time:", err);
     }

--- a/app/webapp/templates/index.html
+++ b/app/webapp/templates/index.html
@@ -34,18 +34,44 @@
             </div>
           </div>
           <div class="form-section select-section">
-            <label for="tournamentSelect" class="select-label"
-              >Wybierz zawody:</label
-            >
-            <select id="tournamentSelect" name="tournamentId" required>
-              <option value="">Pobieram...</option>
-            </select>
+            <label class="select-label">Wybierz zawody:</label>
+            <div class="combobox-wrapper">
+              <button
+                type="button"
+                class="combobox-trigger"
+                id="tournamentTrigger"
+              >
+                <span class="combobox-trigger-text" id="tournamentDisplay"
+                  >Pobieram...</span
+                >
+                <span class="combobox-arrow" aria-hidden="true">▾</span>
+              </button>
+              <ul
+                id="tournamentDropdown"
+                class="combobox-dropdown"
+                role="listbox"
+                hidden
+              ></ul>
+            </div>
           </div>
           <div class="form-section select-section">
-            <label for="clubSelect" class="select-label">Wybierz klub:</label>
-            <select id="clubSelect" name="clubId" required>
-              <option value="">Pobieram...</option>
-            </select>
+            <label for="clubInput" class="select-label">Wybierz klub:</label>
+            <div class="combobox-wrapper">
+              <input
+                type="text"
+                id="clubInput"
+                autocomplete="off"
+                placeholder="Wpisz lub wybierz klub..."
+              />
+              <ul
+                id="clubDropdown"
+                class="combobox-dropdown"
+                role="listbox"
+                hidden
+              ></ul>
+              <input type="hidden" id="clubAcademy" />
+              <input type="hidden" id="clubBranch" />
+            </div>
           </div>
           <div class="form-section button-section">
             <button type="submit">Pokaż Harmonogram</button>

--- a/app/webapp/tests/test_main.py
+++ b/app/webapp/tests/test_main.py
@@ -1,19 +1,19 @@
-import pytest
 from unittest.mock import MagicMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
 from main import app
-from martialmatch_scraper import (
-    ALLOWED_CLUBS,
-    participants_cache,
-    schedule_cache,
-    tournaments_cache,
-)
+from martialmatch_scraper import (ALLOWED_CLUBS, participants_cache,
+                                  schedule_cache, tournaments_cache)
 from utils import EventNotFoundHTTPError
 
 client = TestClient(app)
-MAX_FIELD_LENGTH = 100
-VALID_CLUB_ID = list(ALLOWED_CLUBS.keys())[0]  # "academia_gorila_warszawa"
+MAX_EVENT_ID_LENGTH = 100
+MAX_ACADEMY_LENGTH = 200
+MAX_BRANCH_LENGTH = 200
+
+VALID_ACADEMY = list(ALLOWED_CLUBS.values())[0]["academy"]
+VALID_BRANCH = list(ALLOWED_CLUBS.values())[0]["branch"]
 
 MOCK_PARTICIPANTS_JSON = {
     "categories": [
@@ -22,7 +22,7 @@ MOCK_PARTICIPANTS_JSON = {
             "competitors": [
                 {
                     "firstName": "Anna",
-                    "lastName": "Kowalska",
+                    "lastName": "Testowa",
                     "academy": "Academia Gorila",
                     "branch": "Warszawa",
                 }
@@ -85,6 +85,7 @@ def test_get_clubs():
     assert len(data["clubs"]) == len(ALLOWED_CLUBS)
     for club in data["clubs"]:
         assert "id" in club and "display_name" in club
+        assert "academy" in club and "branch" in club
         assert club["id"] in ALLOWED_CLUBS
 
 
@@ -103,13 +104,17 @@ def test_get_participants_returns_merged_schedule():
     with patch("martialmatch_scraper.make_api_request", side_effect=_mock_api):
         response = client.get(
             "/api/participants",
-            params={"event_id": "123", "club_id": "academia_gorila_warszawa"},
+            params={
+                "event_id": "123",
+                "academy": VALID_ACADEMY,
+                "branch": VALID_BRANCH,
+            },
         )
     assert response.status_code == 200
     schedule = response.json()["schedule"]
     assert "Dzień 1" in schedule
     item = schedule["Dzień 1"][0]
-    assert item["name"] == "Anna Kowalska"
+    assert item["name"] == "Anna Testowa"
     assert item["category"] == "adult; kobiety; -58 kg"
     assert item["mat"] == "Mata 1"
     assert "time" in item
@@ -123,10 +128,16 @@ def test_get_participants_no_matching_competitors():
             return _make_response(json_data={"categories": []})
         return _make_response(json_data=MOCK_SCHEDULE_JSON)
 
-    with patch("martialmatch_scraper.make_api_request", side_effect=mock_no_competitors):
+    with patch(
+        "martialmatch_scraper.make_api_request", side_effect=mock_no_competitors
+    ):
         response = client.get(
             "/api/participants",
-            params={"event_id": "123", "club_id": "academia_gorila_warszawa"},
+            params={
+                "event_id": "123",
+                "academy": VALID_ACADEMY,
+                "branch": VALID_BRANCH,
+            },
         )
     assert response.status_code == 200
     data = response.json()
@@ -140,7 +151,11 @@ def test_get_participants_event_not_found():
     ):
         response = client.get(
             "/api/participants",
-            params={"event_id": "999999", "club_id": "academia_gorila_warszawa"},
+            params={
+                "event_id": "999999",
+                "academy": VALID_ACADEMY,
+                "branch": VALID_BRANCH,
+            },
         )
     assert response.status_code == 200
     data = response.json()
@@ -149,25 +164,25 @@ def test_get_participants_event_not_found():
 
 
 @pytest.mark.parametrize(
-    "event_id,club_id",
+    "event_id,academy,branch",
     [
-        ("123", "invalid_club"),
-        ("", VALID_CLUB_ID),
-        ("123", ""),
-        ("x" * (MAX_FIELD_LENGTH + 1), VALID_CLUB_ID),
-        ("123", "x" * (MAX_FIELD_LENGTH + 1)),
+        ("", VALID_ACADEMY, VALID_BRANCH),
+        ("123", "", ""),
+        ("x" * (MAX_EVENT_ID_LENGTH + 1), VALID_ACADEMY, VALID_BRANCH),
+        ("123", "x" * (MAX_ACADEMY_LENGTH + 1), ""),
+        ("123", VALID_ACADEMY, "x" * (MAX_BRANCH_LENGTH + 1)),
     ],
     ids=[
-        "invalid_club_id",
         "empty_event_id",
-        "empty_club_id",
+        "empty_academy",
         "event_id_too_long",
-        "club_id_too_long",
+        "academy_too_long",
+        "branch_too_long",
     ],
 )
-def test_get_participants_returns_400_for_invalid_input(event_id, club_id):
+def test_get_participants_returns_400_for_invalid_input(event_id, academy, branch):
     response = client.get(
         "/api/participants",
-        params={"event_id": event_id, "club_id": club_id},
+        params={"event_id": event_id, "academy": academy, "branch": branch},
     )
     assert response.status_code == 400


### PR DESCRIPTION
- Replace club <select> with a combobox: text input with a filterable dropdown; featured clubs (ALLOWED_CLUBS) appear first with a ★ badge, then all clubs participating in the selected competition (fetched via new GET /api/event-clubs endpoint)
- Replace tournament <select> with a styled click-only custom dropdown matching the combobox appearance (trigger button + ul, arrow indicator)
- Switch /api/participants from club_id to academy + branch params, removing the ALLOWED_CLUBS whitelist restriction so any club can be searched
- Extract _fetch_participants_json as a shared cached layer so fetch_event_clubs and fetch_bjj_participants both hit the cache on the second call instead of making duplicate HTTP requests to MartialMatch
- Fix race condition in loadEventClubs: stale responses for a tournament the user has navigated away from are discarded
- Fix CSS specificity bug: .combobox-trigger now explicitly resets font-weight, min-width, and hover/active transforms inherited from the global button rule
- Fix unescaped day name in buildDayHtml
- Add input validation (min/max length) to /api/event-clubs